### PR TITLE
ci: fix coverage export step and stabilize test imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,32 @@ jobs:
 
       - name: Generate code coverage report
         run: |
+          set -e
           LLVM_COV="$(dirname $(which swift))/llvm-cov"
-          PROFDATA=$(find .build -name "*.profdata" | head -1)
-          TEST_BINARY=$(find .build -name "*PackageTests.xctest" | head -1)/Contents/MacOS/*
-          
-          $LLVM_COV export -format="lcov" -instr-profile="$PROFDATA" $TEST_BINARY -ignore-filename-regex=".build|Tests" > coverage.lcov
+          PROFDATA=$(find .build -name "*.profdata" | head -1 || true)
+          TEST_BUNDLE=$(find .build -type d -name "*.xctest" | head -1 || true)
+
+          if [ -z "$PROFDATA" ] || [ ! -f "$PROFDATA" ]; then
+            echo "No .profdata found; skipping coverage export"
+            exit 0
+          fi
+
+          if [ -z "$TEST_BUNDLE" ] || [ ! -d "$TEST_BUNDLE" ]; then
+            echo "No test bundle found; skipping coverage export"
+            exit 0
+          fi
+
+          if [ -d "$TEST_BUNDLE/Contents/MacOS" ]; then
+            TEST_BINARY="$TEST_BUNDLE/Contents/MacOS/$(ls -1 "$TEST_BUNDLE/Contents/MacOS" | head -1)"
+          else
+            echo "Test bundle missing Contents/MacOS; skipping coverage export"
+            exit 0
+          fi
+
+          echo "Using profdata: $PROFDATA"
+          echo "Using test binary: $TEST_BINARY"
+
+          "$LLVM_COV" export -format="lcov" -instr-profile="$PROFDATA" "$TEST_BINARY" -ignore-filename-regex=".build|Tests" > coverage.lcov
 
       - name: Generate Coverage Summary
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           AUDIOCAP_VERSION: ${{ needs.version.outputs.version }}
           AUDIOCAP_GIT_COMMIT: ${{ github.sha }}
           AUDIOCAP_BUILD_DATE: ${{ github.event.head_commit.timestamp }}
-        run: swift test --enable-code-coverage | cat
+        run: set -o pipefail; swift test --enable-code-coverage | cat
 
       - name: Generate code coverage report
         run: |

--- a/Package.swift
+++ b/Package.swift
@@ -36,12 +36,18 @@ let package = Package(
         ),
         .testTarget(
             name: "AudiocapRecorderTests",
-            dependencies: ["AudiocapRecorder"],
+            dependencies: [
+                "AudiocapRecorder",
+                "Core"
+            ],
             path: "Tests/AudiocapRecorderTests"
         ),
         .testTarget(
             name: "SineCaptureTests",
-            dependencies: ["AudiocapRecorder"],
+            dependencies: [
+                "AudiocapRecorder",
+                "Core"
+            ],
             path: "Tests/Integration/SineCaptureTests"
         ),
         .executableTarget(

--- a/Sources/CLI/Reexports.swift
+++ b/Sources/CLI/Reexports.swift
@@ -1,0 +1,1 @@
+@_exported import Core

--- a/Tests/AudiocapRecorderTests/AACEncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/AACEncoderTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class AACEncoderTests: XCTestCase {
     func testCreateAACSettingsCBRAndVBR() throws {
         let enc = AACEncoder()

--- a/Tests/AudiocapRecorderTests/AACEncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/AACEncoderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class AACEncoderTests: XCTestCase {
     func testCreateAACSettingsCBRAndVBR() throws {
         let enc = AACEncoder()

--- a/Tests/AudiocapRecorderTests/AACEncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/AACEncoderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class AACEncoderTests: XCTestCase {
     func testCreateAACSettingsCBRAndVBR() throws {

--- a/Tests/AudiocapRecorderTests/AACEncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/AACEncoderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class AACEncoderTests: XCTestCase {
     func testCreateAACSettingsCBRAndVBR() throws {
         let enc = AACEncoder()

--- a/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
+++ b/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class ALACConfigurationTests: XCTestCase {
     func testValidateAcceptsTypicalConfig() throws {
         let cfg = ALACConfiguration(sampleRate: 48_000, channelCount: 2, bitDepth: 16, quality: .max)

--- a/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
+++ b/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class ALACConfigurationTests: XCTestCase {
     func testValidateAcceptsTypicalConfig() throws {

--- a/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
+++ b/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class ALACConfigurationTests: XCTestCase {
     func testValidateAcceptsTypicalConfig() throws {
         let cfg = ALACConfiguration(sampleRate: 48_000, channelCount: 2, bitDepth: 16, quality: .max)

--- a/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
+++ b/Tests/AudiocapRecorderTests/ALACConfigurationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class ALACConfigurationTests: XCTestCase {
     func testValidateAcceptsTypicalConfig() throws {
         let cfg = ALACConfiguration(sampleRate: 48_000, channelCount: 2, bitDepth: 16, quality: .max)

--- a/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class AdaptiveBitrateControllerTests: XCTestCase {
     private func makeBuffer(sineHz: Double?, noiseAmplitude: Float, frames: Int = 4096, sampleRate: Double = 48000, channels: Int = 2) -> AVAudioPCMBuffer {

--- a/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class AdaptiveBitrateControllerTests: XCTestCase {
     private func makeBuffer(sineHz: Double?, noiseAmplitude: Float, frames: Int = 4096, sampleRate: Double = 48000, channels: Int = 2) -> AVAudioPCMBuffer {
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: AVAudioChannelCount(channels))!

--- a/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class AdaptiveBitrateControllerTests: XCTestCase {
     private func makeBuffer(sineHz: Double?, noiseAmplitude: Float, frames: Int = 4096, sampleRate: Double = 48000, channels: Int = 2) -> AVAudioPCMBuffer {
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: AVAudioChannelCount(channels))!

--- a/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/AdaptiveBitrateControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class AdaptiveBitrateControllerTests: XCTestCase {
     private func makeBuffer(sineHz: Double?, noiseAmplitude: Float, frames: Int = 4096, sampleRate: Double = 48000, channels: Int = 2) -> AVAudioPCMBuffer {
         let format = AVAudioFormat(standardFormatWithSampleRate: sampleRate, channels: AVAudioChannelCount(channels))!

--- a/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 private final class DeniedPermissionManager: PermissionManaging {
     func checkScreenRecordingPermission() -> Bool { false }

--- a/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 private final class DeniedPermissionManager: PermissionManaging {
     func checkScreenRecordingPermission() -> Bool { false }
     func requestScreenRecordingPermission() {}

--- a/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 private final class DeniedPermissionManager: PermissionManaging {
     func checkScreenRecordingPermission() -> Bool { false }
     func requestScreenRecordingPermission() {}

--- a/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioCapturerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 private final class DeniedPermissionManager: PermissionManaging {
     func checkScreenRecordingPermission() -> Bool { false }
     func requestScreenRecordingPermission() {}

--- a/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 private final class StubEngine: CompressionEngineProtocol {
     var lastCreated: AVAudioFile?
     var lastProcessedFrames: AVAudioFrameCount = 0

--- a/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 private final class StubEngine: CompressionEngineProtocol {
     var lastCreated: AVAudioFile?
     var lastProcessedFrames: AVAudioFrameCount = 0

--- a/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 private final class StubEngine: CompressionEngineProtocol {
     var lastCreated: AVAudioFile?
     var lastProcessedFrames: AVAudioFrameCount = 0

--- a/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorCompressionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 private final class StubEngine: CompressionEngineProtocol {
     var lastCreated: AVAudioFile?

--- a/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class AudioProcessorTests: XCTestCase {
     func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1) -> AVAudioPCMBuffer {

--- a/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class AudioProcessorTests: XCTestCase {
     func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1) -> AVAudioPCMBuffer {
         let frames = AVAudioFrameCount(seconds * sampleRate)

--- a/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class AudioProcessorTests: XCTestCase {
     func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1) -> AVAudioPCMBuffer {
         let frames = AVAudioFrameCount(seconds * sampleRate)

--- a/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
+++ b/Tests/AudiocapRecorderTests/AudioProcessorTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class AudioProcessorTests: XCTestCase {
     func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1) -> AVAudioPCMBuffer {
         let frames = AVAudioFrameCount(seconds * sampleRate)

--- a/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class CompressionAdvisorTests: XCTestCase {
     func testEstimateSizeMatchesBitrate() {
         let adv = CompressionAdvisor()

--- a/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class CompressionAdvisorTests: XCTestCase {
     func testEstimateSizeMatchesBitrate() {
         let adv = CompressionAdvisor()

--- a/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionAdvisorTests: XCTestCase {
     func testEstimateSizeMatchesBitrate() {

--- a/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAdvisorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class CompressionAdvisorTests: XCTestCase {
     func testEstimateSizeMatchesBitrate() {
         let adv = CompressionAdvisor()

--- a/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionAutoSelectorTests: XCTestCase {
     func testAutoSelectForSpeechShortDurationPrefersAAC() {

--- a/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class CompressionAutoSelectorTests: XCTestCase {
     func testAutoSelectForSpeechShortDurationPrefersAAC() {
         let selector = CompressionAutoSelector()

--- a/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class CompressionAutoSelectorTests: XCTestCase {
     func testAutoSelectForSpeechShortDurationPrefersAAC() {
         let selector = CompressionAutoSelector()

--- a/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionAutoSelectorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class CompressionAutoSelectorTests: XCTestCase {
     func testAutoSelectForSpeechShortDurationPrefersAAC() {
         let selector = CompressionAutoSelector()

--- a/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class CompressionControllerTests: XCTestCase {
     func testInitializeAACValidConfig() throws {
         let ctrl = CompressionController()

--- a/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class CompressionControllerTests: XCTestCase {
     func testInitializeAACValidConfig() throws {
         let ctrl = CompressionController()

--- a/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionControllerTests: XCTestCase {
     func testInitializeAACValidConfig() throws {

--- a/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionControllerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class CompressionControllerTests: XCTestCase {
     func testInitializeAACValidConfig() throws {
         let ctrl = CompressionController()

--- a/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class CompressionIntegrationTests: XCTestCase {
     func testAACEstimatedFileSizeRoughlyMatchesBitrate() throws {
         let enc = AACEncoder()

--- a/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class CompressionIntegrationTests: XCTestCase {
     func testAACEstimatedFileSizeRoughlyMatchesBitrate() throws {
         let enc = AACEncoder()

--- a/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionIntegrationTests: XCTestCase {
     func testAACEstimatedFileSizeRoughlyMatchesBitrate() throws {

--- a/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionIntegrationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class CompressionIntegrationTests: XCTestCase {
     func testAACEstimatedFileSizeRoughlyMatchesBitrate() throws {
         let enc = AACEncoder()

--- a/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class CompressionMigrationTests: XCTestCase {
     func testDryRunCreatesOutputFile() throws {
         let migrator = CompressionMigration()

--- a/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class CompressionMigrationTests: XCTestCase {
     func testDryRunCreatesOutputFile() throws {
         let migrator = CompressionMigration()

--- a/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class CompressionMigrationTests: XCTestCase {
     func testDryRunCreatesOutputFile() throws {
         let migrator = CompressionMigration()

--- a/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionMigrationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionMigrationTests: XCTestCase {
     func testDryRunCreatesOutputFile() throws {

--- a/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class CompressionModelsTests: XCTestCase {
     func testCompressionFormatFileExtensionMapping() {
         XCTAssertEqual(CompressionConfiguration.CompressionFormat.aac.fileExtension, "m4a")

--- a/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class CompressionModelsTests: XCTestCase {
     func testCompressionFormatFileExtensionMapping() {
         XCTAssertEqual(CompressionConfiguration.CompressionFormat.aac.fileExtension, "m4a")

--- a/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class CompressionModelsTests: XCTestCase {
     func testCompressionFormatFileExtensionMapping() {
         XCTAssertEqual(CompressionConfiguration.CompressionFormat.aac.fileExtension, "m4a")

--- a/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionModelsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionModelsTests: XCTestCase {
     func testCompressionFormatFileExtensionMapping() {

--- a/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class CompressionValidationTests: XCTestCase {
     func testIntegrityDetectsMissingOrEmptyFile() {

--- a/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class CompressionValidationTests: XCTestCase {
     func testIntegrityDetectsMissingOrEmptyFile() {
         let v = CompressionValidator()

--- a/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class CompressionValidationTests: XCTestCase {
     func testIntegrityDetectsMissingOrEmptyFile() {
         let v = CompressionValidator()

--- a/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
+++ b/Tests/AudiocapRecorderTests/CompressionValidationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class CompressionValidationTests: XCTestCase {
     func testIntegrityDetectsMissingOrEmptyFile() {
         let v = CompressionValidator()

--- a/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
+++ b/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class CoreInterfacesTests: XCTestCase {
     func testGenerateTimestampedFilenameFormat() throws {
         // Format: yyyy-MM-dd-HH-mm-ss.<ext>

--- a/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
+++ b/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class CoreInterfacesTests: XCTestCase {
     func testGenerateTimestampedFilenameFormat() throws {
         // Format: yyyy-MM-dd-HH-mm-ss.<ext>

--- a/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
+++ b/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class CoreInterfacesTests: XCTestCase {
     func testGenerateTimestampedFilenameFormat() throws {

--- a/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
+++ b/Tests/AudiocapRecorderTests/CoreInterfacesTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class CoreInterfacesTests: XCTestCase {
     func testGenerateTimestampedFilenameFormat() throws {
         // Format: yyyy-MM-dd-HH-mm-ss.<ext>

--- a/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
+++ b/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class EightChannelWAVTests: XCTestCase {
     private func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1, amplitude: Float = 0.5) -> AVAudioPCMBuffer {
         let frames = AVAudioFrameCount(seconds * sampleRate)

--- a/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
+++ b/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class EightChannelWAVTests: XCTestCase {
     private func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1, amplitude: Float = 0.5) -> AVAudioPCMBuffer {
         let frames = AVAudioFrameCount(seconds * sampleRate)

--- a/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
+++ b/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class EightChannelWAVTests: XCTestCase {
     private func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1, amplitude: Float = 0.5) -> AVAudioPCMBuffer {

--- a/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
+++ b/Tests/AudiocapRecorderTests/EightChannelWAVTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class EightChannelWAVTests: XCTestCase {
     private func makeSineBuffer(freq: Double, seconds: Double = 0.1, sampleRate: Double = 48_000, channels: AVAudioChannelCount = 1, amplitude: Float = 0.5) -> AVAudioPCMBuffer {
         let frames = AVAudioFrameCount(seconds * sampleRate)

--- a/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
+++ b/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class ErrorPresenterTests: XCTestCase {
     func testPermissionDeniedMessage() {
         let presenter = ErrorPresenter()

--- a/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
+++ b/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class ErrorPresenterTests: XCTestCase {
     func testPermissionDeniedMessage() {
         let presenter = ErrorPresenter()

--- a/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
+++ b/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class ErrorPresenterTests: XCTestCase {
     func testPermissionDeniedMessage() {
         let presenter = ErrorPresenter()

--- a/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
+++ b/Tests/AudiocapRecorderTests/ErrorPresenterTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class ErrorPresenterTests: XCTestCase {
     func testPermissionDeniedMessage() {

--- a/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class FileControllerCompressedTests: XCTestCase {
     func testCreateCompressedFileM4AAndMP3() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class FileControllerCompressedTests: XCTestCase {
     func testCreateCompressedFileM4AAndMP3() throws {

--- a/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class FileControllerCompressedTests: XCTestCase {
     func testCreateCompressedFileM4AAndMP3() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerCompressedTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class FileControllerCompressedTests: XCTestCase {
     func testCreateCompressedFileM4AAndMP3() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class FileControllerMetadataTests: XCTestCase {
     func testWriteSessionMetadataCreatesJSONFile() throws {

--- a/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class FileControllerMetadataTests: XCTestCase {
     func testWriteSessionMetadataCreatesJSONFile() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class FileControllerMetadataTests: XCTestCase {
     func testWriteSessionMetadataCreatesJSONFile() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerMetadataTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class FileControllerMetadataTests: XCTestCase {
     func testWriteSessionMetadataCreatesJSONFile() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class FileControllerTests: XCTestCase {
     func testCreateDirectoryAndWriteFile() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class FileControllerTests: XCTestCase {
     func testCreateDirectoryAndWriteFile() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class FileControllerTests: XCTestCase {
     func testCreateDirectoryAndWriteFile() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/FileControllerTests.swift
+++ b/Tests/AudiocapRecorderTests/FileControllerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class FileControllerTests: XCTestCase {
     func testCreateDirectoryAndWriteFile() throws {

--- a/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class InputDeviceManagerTests: XCTestCase {
     

--- a/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class InputDeviceManagerTests: XCTestCase {
     
     // Helper methods

--- a/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class InputDeviceManagerTests: XCTestCase {
     
     // Helper methods

--- a/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/InputDeviceManagerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class InputDeviceManagerTests: XCTestCase {
     
     // Helper methods

--- a/Tests/AudiocapRecorderTests/LoggerTests.swift
+++ b/Tests/AudiocapRecorderTests/LoggerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 private final class BufferSink: LogSink {
     var messages: [String] = []

--- a/Tests/AudiocapRecorderTests/LoggerTests.swift
+++ b/Tests/AudiocapRecorderTests/LoggerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 private final class BufferSink: LogSink {
     var messages: [String] = []
     func write(_ message: String) { messages.append(message) }

--- a/Tests/AudiocapRecorderTests/LoggerTests.swift
+++ b/Tests/AudiocapRecorderTests/LoggerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 private final class BufferSink: LogSink {
     var messages: [String] = []
     func write(_ message: String) { messages.append(message) }

--- a/Tests/AudiocapRecorderTests/LoggerTests.swift
+++ b/Tests/AudiocapRecorderTests/LoggerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 private final class BufferSink: LogSink {
     var messages: [String] = []
     func write(_ message: String) { messages.append(message) }

--- a/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class LossyCompressionEngineTests: XCTestCase {
     func testInitWithAACAndProcessProgress() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 128, quality: .medium, enableVBR: true, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class LossyCompressionEngineTests: XCTestCase {
     func testInitWithAACAndProcessProgress() throws {

--- a/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class LossyCompressionEngineTests: XCTestCase {
     func testInitWithAACAndProcessProgress() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 128, quality: .medium, enableVBR: true, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyCompressionEngineTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class LossyCompressionEngineTests: XCTestCase {
     func testInitWithAACAndProcessProgress() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 128, quality: .medium, enableVBR: true, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class LossyEndToEndTests: XCTestCase {
     func testAACEndToEndWritesM4AReadable() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 128, quality: .medium, enableVBR: false, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class LossyEndToEndTests: XCTestCase {
     func testAACEndToEndWritesM4AReadable() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 128, quality: .medium, enableVBR: false, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class LossyEndToEndTests: XCTestCase {
     func testAACEndToEndWritesM4AReadable() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 128, quality: .medium, enableVBR: false, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyEndToEndTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class LossyEndToEndTests: XCTestCase {
     func testAACEndToEndWritesM4AReadable() throws {

--- a/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class LossyMultiChannelSimulationTests: XCTestCase {
     func testSimulatedMultiChannelWithLossyEngineDoesNotCrash() throws {
         // Simulate process stereo + 6 mono inputs => 8-channel combine, with lossy engine receiving process mono

--- a/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class LossyMultiChannelSimulationTests: XCTestCase {
     func testSimulatedMultiChannelWithLossyEngineDoesNotCrash() throws {
         // Simulate process stereo + 6 mono inputs => 8-channel combine, with lossy engine receiving process mono

--- a/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class LossyMultiChannelSimulationTests: XCTestCase {
     func testSimulatedMultiChannelWithLossyEngineDoesNotCrash() throws {

--- a/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyMultiChannelSimulationTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class LossyMultiChannelSimulationTests: XCTestCase {
     func testSimulatedMultiChannelWithLossyEngineDoesNotCrash() throws {
         // Simulate process stereo + 6 mono inputs => 8-channel combine, with lossy engine receiving process mono

--- a/Tests/AudiocapRecorderTests/LossyStressTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyStressTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class LossyStressTests: XCTestCase {
     func testAACStressLargeBuffers() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 192, quality: .high, enableVBR: false, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyStressTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyStressTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class LossyStressTests: XCTestCase {
     func testAACStressLargeBuffers() throws {

--- a/Tests/AudiocapRecorderTests/LossyStressTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyStressTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class LossyStressTests: XCTestCase {
     func testAACStressLargeBuffers() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 192, quality: .high, enableVBR: false, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/LossyStressTests.swift
+++ b/Tests/AudiocapRecorderTests/LossyStressTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class LossyStressTests: XCTestCase {
     func testAACStressLargeBuffers() throws {
         let cfg = CompressionConfiguration(format: .aac, bitrate: 192, quality: .high, enableVBR: false, sampleRate: 44100, channelCount: 2, enableMultiChannel: false)

--- a/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class MP3EncoderTests: XCTestCase {
     func testInitializeConstraints() {
         let enc = MP3Encoder()

--- a/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class MP3EncoderTests: XCTestCase {
     func testInitializeConstraints() {
         let enc = MP3Encoder()

--- a/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class MP3EncoderTests: XCTestCase {
     func testInitializeConstraints() {
         let enc = MP3Encoder()

--- a/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
+++ b/Tests/AudiocapRecorderTests/MP3EncoderTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class MP3EncoderTests: XCTestCase {
     func testInitializeConstraints() {

--- a/Tests/AudiocapRecorderTests/MultiChannelTests.swift
+++ b/Tests/AudiocapRecorderTests/MultiChannelTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import AudiocapRecorder
+ import Core
 final class MultiChannelTests: XCTestCase {
     func testChannelMappingJSONRoundtrip() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/MultiChannelTests.swift
+++ b/Tests/AudiocapRecorderTests/MultiChannelTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
-@testable import AudiocapRecorder
+ import Core
 
 final class MultiChannelTests: XCTestCase {
     func testChannelMappingJSONRoundtrip() throws {

--- a/Tests/AudiocapRecorderTests/MultiChannelTests.swift
+++ b/Tests/AudiocapRecorderTests/MultiChannelTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 import AVFoundation
  import Core
-
 final class MultiChannelTests: XCTestCase {
     func testChannelMappingJSONRoundtrip() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/MultiChannelTests.swift
+++ b/Tests/AudiocapRecorderTests/MultiChannelTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AVFoundation
- import Core
+ import AudiocapRecorder
 final class MultiChannelTests: XCTestCase {
     func testChannelMappingJSONRoundtrip() throws {
         let fc = FileController()

--- a/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class ProcessManagerTests: XCTestCase {
     func testInvalidRegexThrows() {

--- a/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class ProcessManagerTests: XCTestCase {
     func testInvalidRegexThrows() {
         let pm = ProcessManager()

--- a/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class ProcessManagerTests: XCTestCase {
     func testInvalidRegexThrows() {
         let pm = ProcessManager()

--- a/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
+++ b/Tests/AudiocapRecorderTests/ProcessManagerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class ProcessManagerTests: XCTestCase {
     func testInvalidRegexThrows() {
         let pm = ProcessManager()

--- a/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
+++ b/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class RecordingTimerTests: XCTestCase {
     func testTimerTicksAndCompletes() async {
         let expectationCompleted = expectation(description: "completed")

--- a/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
+++ b/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class RecordingTimerTests: XCTestCase {
     func testTimerTicksAndCompletes() async {

--- a/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
+++ b/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class RecordingTimerTests: XCTestCase {
     func testTimerTicksAndCompletes() async {
         let expectationCompleted = expectation(description: "completed")

--- a/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
+++ b/Tests/AudiocapRecorderTests/RecordingTimerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class RecordingTimerTests: XCTestCase {
     func testTimerTicksAndCompletes() async {
         let expectationCompleted = expectation(description: "completed")

--- a/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
+++ b/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import AudiocapRecorder
+ import Core
 
 final class SignalHandlerTests: XCTestCase {
     func testSignalHandlerReceivesSignal() async {

--- a/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
+++ b/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import AudiocapRecorder
+ import Core
 final class SignalHandlerTests: XCTestCase {
     func testSignalHandlerReceivesSignal() async {
         let handler = SignalHandler(signalNumber: SIGUSR1, queue: .main)

--- a/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
+++ b/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
  import Core
-
 final class SignalHandlerTests: XCTestCase {
     func testSignalHandlerReceivesSignal() async {
         let handler = SignalHandler(signalNumber: SIGUSR1, queue: .main)

--- a/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
+++ b/Tests/AudiocapRecorderTests/SignalHandlerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
- import Core
+ import AudiocapRecorder
 final class SignalHandlerTests: XCTestCase {
     func testSignalHandlerReceivesSignal() async {
         let handler = SignalHandler(signalNumber: SIGUSR1, queue: .main)


### PR DESCRIPTION
- **ci: fix coverage step pipefail and re-export Core from CLI so tests see Core symbols; link tests against Core**
- **test: switch Core-facing tests to '@testable import Core'**
- **test: ensure '@testable import Core' for internal API access**
- **tests: revert imports to '@testable import AudiocapRecorder'; rely on CLI re-export of Core**
- **tests: switch unit tests back to '@testable import Core' (exclude CLITests)**
- **ci(coverage): robustly locate test bundle and skip export when artifacts missing; prevent step failure**
